### PR TITLE
fix(dazzle-update): clarify no-upstream finding header and summary label

### DIFF
--- a/src/dazzlecmd/projects/dazzletools/dazzle-update/dazzle_update.py
+++ b/src/dazzlecmd/projects/dazzletools/dazzle-update/dazzle_update.py
@@ -612,7 +612,7 @@ def render_text(records, findings, meta, pal=None):
     for kind, label in (("unpushed", "to push"),
                         ("stale-install-metadata", "to reinstall"),
                         ("dirty", "dirty"),
-                        ("no-upstream", "unbacked")):
+                        ("no-upstream", "untracked")):
         if counts.get(kind):
             parts.append(pal(FINDING_COLOURS[kind],
                              f"{counts[kind]} {label}"))

--- a/src/dazzlecmd/projects/dazzletools/dazzle-update/ecosystem.py
+++ b/src/dazzlecmd/projects/dazzletools/dazzle-update/ecosystem.py
@@ -129,7 +129,7 @@ def resolve_kinds(names):
 
 FINDING_LABELS = {
     "unpushed": "NEEDS PUSH -- work that exists only on this box",
-    "no-upstream": "NO UPSTREAM -- not backed up anywhere",
+    "no-upstream": "NO UPSTREAM -- branch has no remote tracking",
     "source-missing": "BROKEN INSTALL -- editable path does not exist",
     "stale-dist-name": ("DIST NAME MISMATCH -- installed under a name the "
                         "repo does not declare"),


### PR DESCRIPTION
## Summary

Fixes #117.

A branch with no tracking configuration is reported under `no-upstream`. The previous header ('not backed up anywhere') and summary part label ('unbacked') conflated missing tracking config with unbacked local commits, causing fully-published branches without upstream config to read as unbacked work.

## Solution

- Update `FINDING_LABELS["no-upstream"]` to `"NO UPSTREAM -- branch has no remote tracking"`.
- Update the summary part label from `"unbacked"` to `"untracked"`.